### PR TITLE
Implemented support to use values of type {value: T, disabled: boolean}.

### DIFF
--- a/projects/forms/src/lib/types.ts
+++ b/projects/forms/src/lib/types.ts
@@ -9,11 +9,11 @@ import { FormControl } from './form-control';
 /**
  * This type marks a property of a form model as property
  * which is intended for an instance of `FormControl`.
- * 
+ *
  * If a property of your form model have a primitive type,
  * in appropriate form field the instance of `FormControl` will be automatically assigned.
  * But if the property have a type that extends `object` - you need `Control<T>`.
- * 
+ *
  * ### Example:
 ```ts
 import { FormBuilder, Control } from '@ng-stack/forms';
@@ -82,9 +82,18 @@ export type FbControlConfig<T, V extends object = ValidatorsModel> = [T] extends
  * Form builder control.
  */
 export type FbControl<T, V extends object = ValidatorsModel> =
-  | T
-  | [T, (ValidatorFn | ValidatorFn[] | AbstractControlOptions)?, (AsyncValidatorFn | AsyncValidatorFn[])?]
+  | FbControlValue<T>
+  | [FbControlValue<T>, (ValidatorFn | ValidatorFn[] | AbstractControlOptions)?, (AsyncValidatorFn | AsyncValidatorFn[])?]
   | FormControl<T, V>;
+
+/**
+ * Value accepted by form builder control
+ */
+type FbControlValue<T> = T | {
+  value: T;
+  disabled: boolean;
+};
+
 
 /**
  * The validation status of the control. There are four possible
@@ -148,9 +157,9 @@ export type ValidationErrors<T extends object = any> = T;
 /**
  * The default validators model, it includes almost all properties of `typeof Validators`,
  * excludes: `prototype`, `compose`, `composeAsync` and `nullValidator`.
- * 
+ *
  * ### Usage
- * 
+ *
 ```ts
 const formControl = new FormControl<string, ValidatorsModel>('some value');
 // OR

--- a/projects/forms/src/lib/types.ts
+++ b/projects/forms/src/lib/types.ts
@@ -82,18 +82,13 @@ export type FbControlConfig<T, V extends object = ValidatorsModel> = [T] extends
  * Form builder control.
  */
 export type FbControl<T, V extends object = ValidatorsModel> =
-  | FbControlValue<T>
-  | [FbControlValue<T>, (ValidatorFn | ValidatorFn[] | AbstractControlOptions)?, (AsyncValidatorFn | AsyncValidatorFn[])?]
+  | (T | { value: T; disabled: boolean })
+  | [
+      T | { value: T; disabled: boolean },
+      (ValidatorFn | ValidatorFn[] | AbstractControlOptions)?,
+      (AsyncValidatorFn | AsyncValidatorFn[])?
+    ]
   | FormControl<T, V>;
-
-/**
- * Value accepted by form builder control
- */
-type FbControlValue<T> = T | {
-  value: T;
-  disabled: boolean;
-};
-
 
 /**
  * The validation status of the control. There are four possible


### PR DESCRIPTION
Implements support for using something as follows:

```ts
fb.group<Data>({
   name: {value: '', disabled: true}
})
```

or

```ts
fb.group<Data>({
   name: [{value: '', disabled: false}, [Validators.required]]
})
```

with:

```ts
interface Data {
  name: string;
}
```